### PR TITLE
Para cargar servicio de usuarios con depdendencia a si mismo

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -2,3 +2,9 @@ services:
     osmos.user:
         class: OsmosUserBundle\Services\User
         arguments: ['%projects.api%', '%projects.outsource%', '%projects.paysheet%']
+
+    # Only works under Outsource project
+    AppBundle\Service\UserService:
+        public: true
+        arguments:
+            - '@osmos.user'


### PR DESCRIPTION
Para cargar el servicio en el bundle, para que no se rompa el proyecto principal al necesitar dependencia de UserBundle.